### PR TITLE
Added livereload filter for .git folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,12 @@ var server = require('gulp-server-livereload');
 gulp.task('webserver', function() {
   gulp.src('.')
     .pipe(server({
-      livereload: true,
+      livereload: {
+        enable: true, // need this set to true to enable livereload
+        filter: function(filePath, cb) {
+          cb( !(/node_modules/.test(filePath)) && !(/\.git/.test(filePath)));
+        }
+      },
       directoryListing: true,
       open: true
     }));


### PR DESCRIPTION
Livereload срабатывал дважды при изменении файла и добавлении его в индекс git 

```
[15:44:03] Livereload: file changed: /Users/loki/git/DisQwerty-browser/index.html          │
[15:44:10] Livereload: file changed: /Users/loki/git/DisQwerty-browser/.git/index
```
